### PR TITLE
NOD-637: Aggiunto il valore della rowKey nel log in caso di errore

### DIFF
--- a/src/main/java/it/gov/pagopa/nodoverifykototablestorage/NodoVerifyKOEventToTableStorage.java
+++ b/src/main/java/it/gov/pagopa/nodoverifykototablestorage/NodoVerifyKOEventToTableStorage.java
@@ -226,7 +226,7 @@ public class NodoVerifyKOEventToTableStorage {
 				tableClient.submitTransaction(values);
 				stringJoiner.set(new StringJoiner(","));
 			} catch (Exception e) {
-				logger.log(Level.SEVERE, () -> "[ALERT][VerifyKOToTS] Persistence Exception - Could not save " + values.size() + " events (partition [" + partition + "], rowKeys range [" + finalCommaSeparatedString + "]) on Azure Table Storage, error: " + e);
+				logger.log(Level.SEVERE, e, () -> "[ALERT][VerifyKOToTS] Persistence Exception - Could not save " + values.size() + " events (partition [" + partition + "], rowKeys range [" + finalCommaSeparatedString + "]) on Azure Table Storage, error: " + e.getMessage());
 			}
 		});
 		logger.info("Done processing events");


### PR DESCRIPTION
… riversamento in table storage

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Add the rowKey field value within the log in case of error when the data is saved on table storage

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
https://pagopa.atlassian.net/browse/NOD-637: Analizzare alert pagopa-p-weu-nodo-verifyko2ts-fn-persistence-exception

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.